### PR TITLE
detect sandbox/live api urls base on client certificate

### DIFF
--- a/src/HMKit.js
+++ b/src/HMKit.js
@@ -36,8 +36,18 @@ import ApiClient from './Utils/ApiClient';
 import InvalidArgumentError from './Errors/InvalidArgumentError';
 
 const API_URLS = {
-  hmxv: 'https://xv-platform.high-mobility.com/v1/',
-  test: 'https://sandbox.api.high-mobility.com/v1/',
+  prod: {
+    xvhm: 'https://api.high-mobility.com/v1/',
+    test: 'https://sandbox.api.high-mobility.com/v1/',
+  },
+  develop: {
+    xvhm: 'https://api.develop.high-mobility.net/v1',
+    test: 'https://sandbox.api.develop.high-mobility.net/v1/',
+  },
+  staging: {
+    xvhm: 'https://api.staging.high-mobility.net/v1',
+    test: 'https://sandbox.api.staging.high-mobility.net/v1/',
+  }
 };
 
 export default class HMKit {
@@ -54,7 +64,7 @@ export default class HMKit {
 
     this.clientPrivateKey = clientPrivateKey;
 
-    this.api = new Api(this.getApiUrl());
+    this.api = new Api(this.getApiUrl('prod'));
     this.apiClient = new ApiClient();
     this.telematics = new Telematics(this);
     this.commands = new Commands(this);
@@ -62,21 +72,21 @@ export default class HMKit {
   }
 
   develop() {
-    this.api = new Api('https://sandbox.api.develop.high-mobility.net/v1/');
+    this.api = new Api(this.getApiUrl('develop'))
     return this;
   }
 
   staging() {
-    this.api = new Api('https://sandbox.api.staging.high-mobility.net/v1/');
+    this.api = new Api(this.getApiUrl('staging'))
     return this;
   }
 
-  getApiUrl() {
+  getApiUrl(env) {
     if (this.clientCertificate && this.clientCertificate.issuer) {
-      return API_URLS[this.clientCertificate.issuer] || API_URLS.test;
+      return API_URLS[env][this.clientCertificate.issuer] || API_URLS[env].test;
     }
 
-    return API_URLS.test;
+    return API_URLS[env].test;
   }
 
   downloadAccessCertificate(...args) {

--- a/test/HMKit.spec.js
+++ b/test/HMKit.spec.js
@@ -1,0 +1,40 @@
+import HMKit from '../src';
+
+const clientPrivateKey = 'mOlRugZvS+2vvoLCzQg8lNzUABljCyPJ91JQl7yvQO0='
+const sandboxClientCertificate =
+  'dGVzdPZ/oYYWgKrJFhGOCcX/U8uWPy3SVh1dVY8r3vb0yFLi8kA1duKvysIPprpqbQw089Z33MdPuFGQU9Le509pmeAcnqiqOrrnVQHC+o+4tdUVLijFkBys6WliZSqwVY7KOu5SXSBY1PU8ophRJKm7X+r26qspCawv1S43ZboFGoyCxIpRUwsi0zsV3Daskx05USIR50X5';
+
+const liveClientCertificate =
+  'eHZobZFfWDseixY2JmLiqGSmtgWEqHpyGU3ro/ICdsXuYNTmqHpr1tSCCJDo9tsYgbRaEvvHTVozzzDHAlwmBBAHH2K7wP9d0upIoTC0eGtXF8J7pocc9l0Lb5pIHCsdnfXASTcRrhnZ8bjmLeYPa+XW8PplCFITLDBmnvYJT9Um6QQ2Isb4DxFR8Qv7Aj3ERIV+mVxGuGEF';
+
+describe(`HMKit`, () => {
+  it(`should use production sandbox url`, () => {
+    const hmkit = new HMKit(sandboxClientCertificate, clientPrivateKey);
+    expect(hmkit.api.url).toBe('https://sandbox.api.high-mobility.com/v1/');
+  });
+
+  it(`should use production live url`, () => {
+    const hmkit = new HMKit(liveClientCertificate, clientPrivateKey);
+    expect(hmkit.api.url).toBe('https://api.high-mobility.com/v1/');
+  });
+
+  it(`should use develop sandbox url`, () => {
+    const hmkit = new HMKit(sandboxClientCertificate, clientPrivateKey).develop();
+    expect(hmkit.api.url).toBe('https://sandbox.api.develop.high-mobility.net/v1/');
+  });
+
+  it(`should use develop live url`, () => {
+    const hmkit = new HMKit(liveClientCertificate, clientPrivateKey).develop();
+    expect(hmkit.api.url).toBe('https://api.develop.high-mobility.net/v1');
+  });
+
+  it(`should use staging sandbox url`, () => {
+    const hmkit = new HMKit(sandboxClientCertificate, clientPrivateKey).staging();
+    expect(hmkit.api.url).toBe('https://sandbox.api.staging.high-mobility.net/v1/');
+  });
+
+  it(`should use staging live url`, () => {
+    const hmkit = new HMKit(liveClientCertificate, clientPrivateKey).staging();
+    expect(hmkit.api.url).toBe('https://api.staging.high-mobility.net/v1');
+  });
+});


### PR DESCRIPTION
This was done only on production with the wrong issuer and it wasn't working.

With this change we can benefit picking sandbox/live api for all the environments


Could you please push the package in npm with a patch bump?